### PR TITLE
Update for pycoin 0.9 refactoring

### DIFF
--- a/cc/validator.py
+++ b/cc/validator.py
@@ -1,4 +1,5 @@
-from pycoin.encoding import a2b_hashed_base58, EncodingError
+from pycoin.encoding.b58 import a2b_hashed_base58
+from pycoin.encoding.exceptions import EncodingError
 
 
 def validate(address, magic_bytes):


### PR DESCRIPTION
Fixes this error after pycoin update to 0.9:

```
  File "/srv/http/lib/python3.7/site-packages/cc/validator.py", line 1, in <module>
    from pycoin.encoding import a2b_hashed_base58, EncodingError
ImportError: cannot import name 'a2b_hashed_base58' from 'pycoin.encoding' (/srv/http/lib/python3.7/site-packages/pycoin/encoding/__init__.py)
```

See https://github.com/richardkiss/pycoin/commit/01b1787ed902df23f99a55deb00d8cd076a906fe#diff-0b03aeb3a96cc39138fbc99d65a6db62